### PR TITLE
add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I noticed that CI fails because of outdated GitHub actions; see https://github.com/JuliaApproximation/FastTransformsForwardDiff.jl/actions/runs/19296086133/job/55178268869. Dependabot will automatically create PRs to update the GitHub action versions.